### PR TITLE
Upgrade for Scuttlebot 12 and Node 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+export

--- a/lib/export-data.js
+++ b/lib/export-data.js
@@ -39,7 +39,9 @@ var self = module.exports = {
                 });
 
                 self.consumeBlobQueue(sbot, exportDir, () => {
-                    fs.writeFile(path.join(exportDir, "messages.txt"), JSON.stringify(log));
+                  fs.writeFile(path.join(exportDir, "messages.txt"), JSON.stringify(log), () => {
+                    console.log('Done!')
+                  })
                     sbot.close();
                 });
             })

--- a/lib/import-data.js
+++ b/lib/import-data.js
@@ -23,7 +23,7 @@ var self = module.exports = {
             var latestLocalSeq = "";
             if (!err)
                 latestLocalSeq = seq.sequence;
-            else if (err && err.name != 'NotFoundError')
+          else if (err && err.message.indexOf('not found') === -1)
                 throw err;
 
             console.log("latest seq:" + latestLocalSeq);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4335 @@
+{
+  "name": "ssb-exporter",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abstract-leveldown": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+      "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+      "requires": {
+        "xtend": "~4.0.0"
+      }
+    },
+    "aligned-block-file": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.3.tgz",
+      "integrity": "sha512-ai/S+nZ9XMjC0ReZfq94OLGCICVBJyhNiKWmF1J+/GVZZaXtYV805plMi9obaWjfNl/QljB+VOsT+wQ7R858xA==",
+      "requires": {
+        "hashlru": "^2.1.0",
+        "int53": "^0.2.4",
+        "mkdirp": "^0.5.1",
+        "obv": "0.0.0",
+        "uint48be": "^1.0.1"
+      },
+      "dependencies": {
+        "obv": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
+          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
+        }
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
+      }
+    },
+    "append-batch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
+      "integrity": "sha1-kiSFjlVpl8zAfxHx7poShTKqDSU="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-single": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
+    },
+    "async-write": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz",
+      "integrity": "sha1-HnYoF9hJzkS/rAeSWkIDZ4cGGxU="
+    },
+    "atomic-file": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-0.0.1.tgz",
+      "integrity": "sha1-bDZlj2xOzjP7o4d3MefCX8gpmbs="
+    },
+    "attach-ware": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
+      "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
+      "requires": {
+        "unherit": "^1.0.0"
+      }
+    },
+    "bail": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-url": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz",
+      "integrity": "sha512-Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ=="
+    },
+    "bash-color": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
+      "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "binary-search": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.4.tgz",
+      "integrity": "sha512-dPxU/vZLnH0tEVjVPgi015oSwqu6oLfCeHywuFRhBE0yM0mYocvleTl8qsdM1YFhRzTRhM1+VzS8XLDVrHPopg=="
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "blake2s": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/blake2s/-/blake2s-1.0.1.tgz",
+      "integrity": "sha1-FZiCKjIOzmqkAbqYKVT4L2GwzXs="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "broadcast-stream": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.2.2.tgz",
+      "integrity": "sha1-eee7FKmrunf3KsklgiAkKo/TkZ0="
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
+      "requires": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
+      "requires": {
+        "typewise-core": "^1.2"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "ccount": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "character-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
+    },
+    "character-entities-html4": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+      "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
+    },
+    "charwise": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
+      "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
+    },
+    "chloride": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.10.tgz",
+      "integrity": "sha512-CbU1ISGiB2JBV6PDXx7hkl8D94d2TPD1BANUMFbr8rZYKJi8De2d3Hu2XDIOLAhXf+8yhoFOdjtLG6fxz3QByQ==",
+      "requires": {
+        "is-electron": "^2.0.0",
+        "sodium-browserify": "^1.2.4",
+        "sodium-browserify-tweetnacl": "^0.2.2",
+        "sodium-chloride": "^1.1.0",
+        "sodium-native": "^2.1.6"
+      }
+    },
+    "chloride-test": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
+      "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
+      "requires": {
+        "json-buffer": "^2.0.11"
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
+      }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "co": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
+    },
+    "commander": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "cont": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
+      "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
+      "requires": {
+        "continuable": "~1.2.0",
+        "continuable-para": "~1.2.0",
+        "continuable-series": "~1.2.0"
+      }
+    },
+    "continuable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
+      "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
+    },
+    "continuable-hash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
+      "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
+      "requires": {
+        "continuable": "~1.1.6"
+      },
+      "dependencies": {
+        "continuable": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+        }
+      }
+    },
+    "continuable-list": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
+      "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
+      "requires": {
+        "continuable": "~1.1.6"
+      },
+      "dependencies": {
+        "continuable": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+        }
+      }
+    },
+    "continuable-para": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
+      "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
+      "requires": {
+        "continuable-hash": "~0.1.4",
+        "continuable-list": "~0.1.5"
+      }
+    },
+    "continuable-series": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
+      "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "deferred-leveldown": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+      "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
+      "requires": {
+        "abstract-leveldown": "~4.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detab": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
+      "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
+      "requires": {
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
+    "dynamic-dijkstra": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dijkstra/-/dynamic-dijkstra-1.0.0.tgz",
+      "integrity": "sha512-AUbCFABXNoon689xft5ROX/fO9pdttZ6wZcMXZ4oH85Bn9rtiMdVHVBbAZ9kxAewdm5L1m+y+n97s8ofwya8WA==",
+      "requires": {
+        "heap": "^0.2.6"
+      }
+    },
+    "ed2curve": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
+      "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
+      "requires": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+    },
+    "emoji-named-characters": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz",
+      "integrity": "sha1-zes20OZgAsS5178d+8Ohmft9QJs="
+    },
+    "emoji-server": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
+      "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
+      "requires": {
+        "emoji-named-characters": "~1.0.2"
+      }
+    },
+    "encoding-down": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.1.tgz",
+      "integrity": "sha512-AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==",
+      "requires": {
+        "abstract-leveldown": "^4.0.0",
+        "level-codec": "^8.0.0",
+        "level-errors": "^1.0.4",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "level-codec": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
+          "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q=="
+        }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "epidemic-broadcast-trees": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-6.3.4.tgz",
+      "integrity": "sha512-ucs3AI3ebPCDFGw8B0SUBwzcY2WqKrbJeqYeeX9KF+XvsO7GFEe0L+1hXPfJcEScfGPByXJNACkYwUFnNaOueQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "push-stream": "^10.0.0"
+      }
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "requires": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "expand-template": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+    },
+    "explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extend.js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz",
+      "integrity": "sha1-D5x6gaHyCLcD6wwxMf5XFqxuzRU="
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "flumecodec": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+      "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+      "requires": {
+        "level-codec": "^6.2.0"
+      }
+    },
+    "flumedb": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.4.9.tgz",
+      "integrity": "sha512-z932cCXHteJXKcwoev8/RfJ9tQ10FeRCZ6Jh55UnxN/ayZraYZvNYObl8ujbho7xQZB1CDt2WTHCN5gEYGBqGw==",
+      "requires": {
+        "cont": "^1.0.3",
+        "explain-error": "^1.0.3",
+        "obv": "0.0.1",
+        "pull-cont": "0.0.0",
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.5.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "flumelog-offset": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.3.1.tgz",
+      "integrity": "sha512-4yYdr8tTL0qOkKqhxAxvNnIwDBaBcLEsJWbyc2wU4Ycaewts9xxcBaxNbORp2KBbTwFaqZAV13HVpfZcO1X/AA==",
+      "requires": {
+        "aligned-block-file": "^1.1.2",
+        "append-batch": "^0.0.1",
+        "explain-error": "^1.0.3",
+        "hashlru": "^2.2.0",
+        "int53": "^0.2.4",
+        "looper": "^4.0.0",
+        "ltgt": "^2.1.3",
+        "obv": "0.0.1",
+        "pull-cursor": "^3.0.0",
+        "pull-looper": "^1.0.0",
+        "uint48be": "^1.0.1"
+      }
+    },
+    "flumeview-hashtable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.4.tgz",
+      "integrity": "sha512-4L52hBelX7dYVAQQ9uPjksqxOCxLwI4NsfEG/+sTM423axT2Poq5cnfdvGm3HzmNowzwDIKtdy429r6PbfKEIw==",
+      "requires": {
+        "async-single": "^1.0.5",
+        "atomic-file": "^1.1.3",
+        "obv": "0.0.1",
+        "pull-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "atomic-file": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
+          "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "flumeview-level": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
+      "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
+      "requires": {
+        "charwise": "^3.0.1",
+        "explain-error": "^1.0.4",
+        "level": "^3.0.1",
+        "ltgt": "^2.1.3",
+        "mkdirp": "^0.5.1",
+        "obv": "0.0.0",
+        "pull-level": "^2.0.3",
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.5.0",
+        "pull-write": "^1.1.1"
+      },
+      "dependencies": {
+        "obv": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
+          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "flumeview-query": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.3.0.tgz",
+      "integrity": "sha512-8QBannTFLICARmflhHpXNeR5hh6IzIyJz4XhKTofzmxq/hXEn1un7aF6P6dRQkOwthENDTbSB07eWKqwnYDKtw==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "flumeview-level": "^3.0.0",
+        "map-filter-reduce": "^3.0.7",
+        "pull-flatmap": "0.0.1",
+        "pull-paramap": "^1.1.3",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "map-filter-reduce": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.1.0.tgz",
+          "integrity": "sha512-os2GlG1lEWRSAvAb9iqfapQ0I1GRXSA+alSjQl0DB7XxNyDx2/VOVAEVhK7EMsqwDDCWNTBSstoo1roc7U5H0w==",
+          "requires": {
+            "binary-search": "^1.2.0",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "^3.4.3",
+            "typewiselite": "^1.0.0"
+          }
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "flumeview-reduce": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.13.tgz",
+      "integrity": "sha512-QN/07+ia3uXpfy8/xWjLI2XGIG67Aiwp9VaOTIqYt6NHP6OfdGfl8nGRPkJRHlkfFbzEouRvJcQBFohWEXMdNQ==",
+      "requires": {
+        "async-single": "^1.0.5",
+        "atomic-file": "^1.1.3",
+        "deep-equal": "^1.0.1",
+        "flumecodec": "0.0.0",
+        "obv": "0.0.0",
+        "pull-notify": "^0.1.1",
+        "pull-stream": "^3.5.0"
+      },
+      "dependencies": {
+        "atomic-file": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
+          "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
+        },
+        "flumecodec": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
+          "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
+          "requires": {
+            "level-codec": "^6.2.0"
+          }
+        },
+        "obv": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
+          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "requires": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "globby": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graphreduce": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/graphreduce/-/graphreduce-3.0.4.tgz",
+      "integrity": "sha1-v0QtCoeOg5AeXvPmUtI/+1uDHtc=",
+      "requires": {
+        "statistics": "^3.3.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-network": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/has-network/-/has-network-0.0.1.tgz",
+      "integrity": "sha1-Pup7RMqpYBeXEkvouonSKMQQFJk="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "hashlru": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.1.tgz",
+      "integrity": "sha1-EPIJmg18BaQPK+r1wdOc8vfavzY="
+    },
+    "he": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
+      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
+    },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+    },
+    "hmac": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha1-Fr2muK1a5whIobnsfG81d9+xmyQ="
+    },
+    "hoox": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
+      "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
+    },
+    "increment-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
+      "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "int53": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
+      "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
+    },
+    "ip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
+      "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
+    },
+    "ip-address": {
+      "version": "5.8.9",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.8.9.tgz",
+      "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
+        "sprintf-js": "1.1.0"
+      }
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
+    "is-alphabetical": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-decimal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-electron": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
+      "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+    },
+    "is-valid-domain": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.5.tgz",
+      "integrity": "sha1-SOcDGfy0MAkjbpazf5hDiJzntRM="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+    },
+    "json-buffer": {
+      "version": "2.0.11",
+      "resolved": "http://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+      "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "layered-graph": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/layered-graph/-/layered-graph-1.0.0.tgz",
+      "integrity": "sha512-GFMTMJ2plvrB6Y+UD9DQKnfHWcSAZawWzJ/RUHR/tR7n9Wl17Q0z99WGSyrSTXAju2SIvWjN3U0MsRNxC2FsJQ==",
+      "requires": {
+        "dynamic-dijkstra": "^1.0.0",
+        "pull-notify": "^0.1.1"
+      }
+    },
+    "level": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
+      "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
+      "requires": {
+        "level-packager": "^2.0.2",
+        "leveldown": "^3.0.0",
+        "opencollective-postinstall": "^2.0.0"
+      }
+    },
+    "level-codec": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+    },
+    "level-errors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+      "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.5",
+        "xtend": "^4.0.0"
+      }
+    },
+    "level-packager": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
+      "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
+      "requires": {
+        "encoding-down": "~4.0.0",
+        "levelup": "^2.0.0"
+      }
+    },
+    "level-post": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+      "requires": {
+        "ltgt": "^2.1.2"
+      }
+    },
+    "level-sublevel": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
+      "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
+      "requires": {
+        "bytewise": "~1.1.0",
+        "levelup": "~0.19.0",
+        "ltgt": "~2.1.1",
+        "pull-defer": "^0.2.2",
+        "pull-level": "^2.0.3",
+        "pull-stream": "^3.6.8",
+        "typewiselite": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+          "requires": {
+            "xtend": "~3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+            }
+          }
+        },
+        "bl": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+          "requires": {
+            "readable-stream": "~1.0.26"
+          }
+        },
+        "deferred-leveldown": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+          "requires": {
+            "abstract-leveldown": "~0.12.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "levelup": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
+          "requires": {
+            "bl": "~0.8.1",
+            "deferred-leveldown": "~0.2.0",
+            "errno": "~0.1.1",
+            "prr": "~0.0.0",
+            "readable-stream": "~1.0.26",
+            "semver": "~5.1.0",
+            "xtend": "~3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+            }
+          }
+        },
+        "ltgt": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
+        },
+        "prr": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "semver": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "leveldown": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
+      "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
+      "requires": {
+        "abstract-leveldown": "~4.0.0",
+        "bindings": "~1.3.0",
+        "fast-future": "~1.0.2",
+        "nan": "~2.10.0",
+        "prebuild-install": "^4.0.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+        }
+      }
+    },
+    "levelup": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+      "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
+      "requires": {
+        "deferred-leveldown": "~3.0.0",
+        "level-errors": "~1.1.0",
+        "level-iterator-stream": "~2.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "libsodium": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.3.tgz",
+      "integrity": "sha512-ld+deUNqSsZYbAobUs63UyduPq8ICp/Ul/5lbvBIYpuSNWpPRU0PIxbW+xXipVZtuopR6fIz9e0tTnNuPMNeqw=="
+    },
+    "libsodium-wrappers": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.3.tgz",
+      "integrity": "sha512-dw5Jh6TZ5qc5rQVZe3JrSO/J05CE+DmAPnqD7Q2glBUE969xZ6o3fchnUxyPlp6ss3x0MFxmdJntveFN+XTg1g==",
+      "requires": {
+        "libsodium": "0.7.3"
+      }
+    },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+    },
+    "lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "^1.0.0"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "requires": {
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
+      }
+    },
+    "longest-streak": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
+      "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
+    },
+    "looper": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+    },
+    "lossy-store": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.3.tgz",
+      "integrity": "sha1-Vi4qkgPYZh9g6HEt5Af72t8nXck=",
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "tape": "^4.6.3"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "map-filter-reduce": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
+      "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
+      "requires": {
+        "binary-search": "^1.2.0",
+        "pull-sink-through": "0.0.0",
+        "pull-stream": "^3.3.0",
+        "typewiselite": "^1.0.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "map-merge": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
+      "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
+    },
+    "markdown-table": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
+      "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
+    "mdmanifest": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/mdmanifest/-/mdmanifest-1.0.8.tgz",
+      "integrity": "sha1-wEiRiDwoyDYC4dBrBaEQN+NZtMg=",
+      "requires": {
+        "minimist": "^1.2.0",
+        "remark": "^3.2.2",
+        "remark-html": "^2.0.2",
+        "word-wrap": "^1.1.0"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "monotonic-timestamp": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
+      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multiblob": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.1.tgz",
+      "integrity": "sha512-AvU9tbDqf3TxYgF1ldo3nVz4HoKI/ZDJBo/znLc6KCRiqr7dQv5vW3i3xh0JKZdLzgKG9JpUiKtwB8E92gn3ZQ==",
+      "requires": {
+        "blake2s": "~1.0.1",
+        "cont": "~1.0.1",
+        "explain-error": "~1.0.1",
+        "mkdirp": "~0.5.0",
+        "pull-cat": "^1.1.8",
+        "pull-defer": "^0.2.2",
+        "pull-file": "^0.5.0",
+        "pull-glob": "~1.0.6",
+        "pull-live": "^1.0.0",
+        "pull-notify": "^0.1.1",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.2",
+        "pull-write-file": "^0.2.1",
+        "rc": "~1.2.8",
+        "rimraf": "~2.2.8",
+        "stream-to-pull-stream": "^1.7.2"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        },
+        "pull-file": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
+          "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
+          "requires": {
+            "pull-utf8-decoder": "^1.0.2"
+          }
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        },
+        "stream-to-pull-stream": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
+          "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+          "requires": {
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
+          }
+        }
+      }
+    },
+    "multiblob-http": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.4.2.tgz",
+      "integrity": "sha512-hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==",
+      "requires": {
+        "pull-stream": "^3.4.3",
+        "stream-to-pull-stream": "^1.7.0"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "stream-to-pull-stream": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
+          "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+          "requires": {
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
+          }
+        }
+      }
+    },
+    "multicb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
+      "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
+    },
+    "multiserver": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.13.4.tgz",
+      "integrity": "sha512-4d2yOvaUhzVMRS7uto2DBdX9q2Q5XFQRfXDJNcQ3rY+ZfF21TOUMpyZ+UE1HK0NhguzmZkk/hWf3oGDzVoR6aQ==",
+      "requires": {
+        "pull-cat": "~1.1.5",
+        "pull-stream": "^3.6.1",
+        "pull-ws": "^3.3.0",
+        "secret-handshake": "^1.1.12",
+        "separator-escape": "0.0.0",
+        "socks": "2.2.1",
+        "stream-to-pull-stream": "^1.7.2"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "secret-handshake": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.13.tgz",
+          "integrity": "sha512-jDpA1kPJGg+jEUOZGvqksQFGPWIx0aA96HpjU+AqIBKIKzmvZeOq0Lfl/XqVC5jviWTVZZM2B8+NqYR38Blz8A==",
+          "requires": {
+            "chloride": "^2.2.7",
+            "deep-equal": "~1.0.0",
+            "pull-box-stream": "^1.0.13",
+            "pull-handshake": "^1.1.1",
+            "pull-stream": "^3.4.5"
+          }
+        },
+        "stream-to-pull-stream": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
+          "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+          "requires": {
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
+          }
+        }
+      }
+    },
+    "muxrpc": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.1.tgz",
+      "integrity": "sha512-r8+tucKMmQiYd8NWGQqAA5r+SlYuU30D/WbYo7E/PztG/jmizQJY5NfmLIJ+GWo+dEC6kIxkr0eY+U0uZexTNg==",
+      "requires": {
+        "explain-error": "^1.0.1",
+        "packet-stream": "~2.0.0",
+        "packet-stream-codec": "^1.1.1",
+        "pull-goodbye": "~0.0.1",
+        "pull-stream": "^3.2.3"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "muxrpc-validation": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-2.0.1.tgz",
+      "integrity": "sha1-zWUNFyAl/p0GQjCqs4ymMo3Rby8=",
+      "requires": {
+        "pull-stream": "^2.28.3",
+        "zerr": "^1.0.1"
+      }
+    },
+    "muxrpcli": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-1.1.0.tgz",
+      "integrity": "sha1-Sum6mGq4JcSlwS/LccbaqB6rUVg=",
+      "requires": {
+        "minimist": "^1.2.0",
+        "pull-stream": "^2.28.3",
+        "stream-to-pull-stream": "^1.6.6",
+        "word-wrap": "^1.1.0"
+      }
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
+    },
+    "nan": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "optional": true
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+    },
+    "node-abi": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
+      "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node-gyp-build": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.4.0.tgz",
+      "integrity": "sha512-YoviGBJYGrPdLOKDIQB0sKxuKy/EEsxzooNkOZak4vSTKT/qH0Pa6dj3t1MJjEQGsefih61IyHDmO1WW7xOFfw==",
+      "optional": true
+    },
+    "non-private-ip": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+      "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
+      "requires": {
+        "ip": "^1.1.5"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        }
+      }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "normalize-uri": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.1.tgz",
+      "integrity": "sha512-bui9/kzRGymbkxJsZEBZgDHK2WJWGOHzR0pCr404EpkpVFTkCOYaRwQTlehUE+7oI70mWNENncCWqUxT/icfHw=="
+    },
+    "npm-prefix": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
+      "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
+      "requires": {
+        "rc": "^1.1.0",
+        "shellsubstitute": "^1.1.0",
+        "untildify": "^2.1.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "observ": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz",
+      "integrity": "sha1-C8ObPin6pfnmyqWQbLg5LfQAqmg="
+    },
+    "observ-debounce": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
+      "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
+      "requires": {
+        "observ": "~0.2.0"
+      }
+    },
+    "obv": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
+      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
+    },
+    "on-change-network": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/on-change-network/-/on-change-network-0.0.2.tgz",
+      "integrity": "sha1-2XcklHf5FyaUnYDoI0batu9FIWs="
+    },
+    "on-wakeup": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
+      "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.0.tgz",
+      "integrity": "sha512-XAe80GycLe2yRGnJsUtt+EO5lk06XYRQt4kJJe53O2kJHPZJOZ+XMF/b47HW96e6LhfKVpwnXVr/s56jhV98jg=="
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "packet-stream": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.4.tgz",
+      "integrity": "sha512-7+oxHdMMs6VhLvvbrDUc8QNuelE9fPKLDdToXBIKLPKOlnoBeMim+/35edp+AnFTLzk3xcogVvQ/jrZyyGsEiw=="
+    },
+    "packet-stream-codec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
+      "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
+      "requires": {
+        "pull-reader": "^1.2.4",
+        "pull-through": "^1.0.17"
+      }
+    },
+    "parse-entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
+      "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "^1.0.0"
+      }
+    },
+    "prebuild-install": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "private-box": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
+      "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
+      "requires": {
+        "chloride": "^2.2.1"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "pull-abortable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz",
+      "integrity": "sha1-cBephMO4NN53usOMELd28i38GEM="
+    },
+    "pull-box-stream": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
+      "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
+      "requires": {
+        "chloride": "^2.2.7",
+        "increment-buffer": "~1.0.0",
+        "pull-reader": "^1.2.5",
+        "pull-stream": "^3.2.3",
+        "pull-through": "^1.0.18",
+        "split-buffer": "~1.0.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-cat": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+    },
+    "pull-cont": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
+      "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
+    },
+    "pull-core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
+      "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
+    },
+    "pull-cursor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
+      "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
+      "requires": {
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.0",
+        "pull-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-defer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
+    },
+    "pull-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
+      "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
+      "requires": {
+        "pull-utf8-decoder": "^1.0.2"
+      }
+    },
+    "pull-flatmap": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz",
+      "integrity": "sha1-E9SURT6PbUeOe7+t5vj+AZf6a7c="
+    },
+    "pull-fs": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
+      "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
+      "requires": {
+        "pull-file": "^0.5.0",
+        "pull-stream": "^3.3.0",
+        "pull-traverse": "^1.0.3",
+        "pull-write-file": "^0.2.1"
+      },
+      "dependencies": {
+        "pull-file": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
+          "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
+          "requires": {
+            "pull-utf8-decoder": "^1.0.2"
+          }
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-glob": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.7.tgz",
+      "integrity": "sha1-7vkV3eZEvdvqjdLgEG1USqy81cI=",
+      "requires": {
+        "pull-fs": "~1.1.6",
+        "pull-stream": "^3.3.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-goodbye": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
+      "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
+      "requires": {
+        "pull-stream": "~3.5.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
+          "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
+        }
+      }
+    },
+    "pull-handshake": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
+      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
+      "requires": {
+        "pull-cat": "^1.1.9",
+        "pull-pair": "~1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.3"
+      }
+    },
+    "pull-hash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-hash/-/pull-hash-1.0.0.tgz",
+      "integrity": "sha1-/K1NJQe/LCsyMfZT3Jv7LbTw2Iw="
+    },
+    "pull-inactivity": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.2.tgz",
+      "integrity": "sha1-N6PW67+sKSzUNfXkgeUHTIwfrXU=",
+      "requires": {
+        "pull-abortable": "~4.0.0",
+        "pull-stream": "^3.4.5"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-level": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+      "requires": {
+        "level-post": "^1.0.7",
+        "pull-cat": "^1.1.9",
+        "pull-live": "^1.0.1",
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.0",
+        "pull-window": "^2.1.4",
+        "stream-to-pull-stream": "^1.7.1"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "stream-to-pull-stream": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
+          "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
+          "requires": {
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
+          }
+        }
+      }
+    },
+    "pull-live": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+      "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+      "requires": {
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-looper": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
+      "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
+      "requires": {
+        "looper": "^4.0.0"
+      }
+    },
+    "pull-many": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
+      "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
+      "requires": {
+        "pull-stream": "^3.4.5"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-next": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-next/-/pull-next-1.0.1.tgz",
+      "integrity": "sha1-A/TX0Zhy/BEUFh6I227PTGXmHlY="
+    },
+    "pull-notify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
+      "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
+      "requires": {
+        "pull-pushable": "^2.0.0"
+      }
+    },
+    "pull-pair": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
+      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
+    },
+    "pull-paramap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
+      "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
+      "requires": {
+        "looper": "^4.0.0"
+      }
+    },
+    "pull-ping": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz",
+      "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
+      "requires": {
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.5",
+        "statistics": "^3.3.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-pushable": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
+    },
+    "pull-rate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
+      "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
+      "requires": {
+        "pull-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-reader": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
+      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
+    },
+    "pull-sink-through": {
+      "version": "0.0.0",
+      "resolved": "http://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
+      "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
+    },
+    "pull-stream": {
+      "version": "2.28.4",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
+      "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
+      "requires": {
+        "pull-core": "~1.1.0"
+      }
+    },
+    "pull-stream-to-stream": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
+      "integrity": "sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k="
+    },
+    "pull-stringify": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npmjs.org/pull-stringify/-/pull-stringify-1.2.2.tgz",
+      "integrity": "sha1-Whw04Adfry8vbUYATjbczTO9fHw="
+    },
+    "pull-through": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
+      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
+      "requires": {
+        "looper": "~3.0.0"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        }
+      }
+    },
+    "pull-traverse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
+      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
+    },
+    "pull-utf8-decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
+      "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
+    },
+    "pull-window": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+      "requires": {
+        "looper": "^2.0.0"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
+        }
+      }
+    },
+    "pull-write": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
+      "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
+      "requires": {
+        "looper": "^4.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-stream": "^3.4.5"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "pull-write-file": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz",
+      "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8="
+    },
+    "pull-ws": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz",
+      "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
+      "requires": {
+        "relative-url": "^1.0.2",
+        "safe-buffer": "^5.1.1",
+        "ws": "^1.1.0"
+      }
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "push-stream": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/push-stream/-/push-stream-10.0.3.tgz",
+      "integrity": "sha1-E9au9LUGxlu8OqYkCajabOFH74c="
+    },
+    "push-stream-to-pull-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/push-stream-to-pull-stream/-/push-stream-to-pull-stream-1.0.3.tgz",
+      "integrity": "sha512-pdE/OKi/jnp9DqGgNRzLY0oVHffn/8TXJmBPzv+ikdvpkeA0J//l5d7TZk1yWwZj9P0JcOIEVDOuHzhXaeBlmw==",
+      "requires": {
+        "pull-looper": "^1.0.0",
+        "push-stream": "^10.0.3"
+      }
+    },
+    "randomatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "relative-url": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
+      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
+    },
+    "remark": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
+      "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
+      "requires": {
+        "camelcase": "^2.0.0",
+        "ccount": "^1.0.0",
+        "chalk": "^1.0.0",
+        "chokidar": "^1.0.5",
+        "collapse-white-space": "^1.0.0",
+        "commander": "^2.0.0",
+        "concat-stream": "^1.0.0",
+        "debug": "^2.0.0",
+        "elegant-spinner": "^1.0.0",
+        "extend.js": "0.0.2",
+        "glob": "^6.0.1",
+        "globby": "^4.0.0",
+        "he": "^0.5.0",
+        "log-update": "^1.0.1",
+        "longest-streak": "^1.0.0",
+        "markdown-table": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "npm-prefix": "^1.0.1",
+        "parse-entities": "^1.0.0",
+        "repeat-string": "^1.5.0",
+        "stringify-entities": "^1.0.0",
+        "to-vfile": "^1.0.0",
+        "trim": "^0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unified": "^2.0.0",
+        "user-home": "^2.0.0",
+        "vfile": "^1.1.0",
+        "vfile-find-down": "^1.0.0",
+        "vfile-find-up": "^1.0.0",
+        "vfile-reporter": "^1.5.0",
+        "ware": "^1.3.0"
+      }
+    },
+    "remark-html": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
+      "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
+      "requires": {
+        "collapse-white-space": "^1.0.0",
+        "detab": "^1.0.0",
+        "normalize-uri": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "trim": "0.0.1",
+        "trim-lines": "^1.0.0",
+        "unist-util-visit": "^1.0.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "resolve": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "scuttlebot": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/scuttlebot/-/scuttlebot-12.0.1.tgz",
+      "integrity": "sha512-Gff+JNKZX1YfOL83Z3rWPAb8MCKVMdHFfgyHMOYeZ84vK63rI+C5zaM3+NQDjUIXn/p6oiiC7dcjUybmjv2y2A==",
+      "requires": {
+        "atomic-file": "0.0.1",
+        "bash-color": "~0.0.3",
+        "broadcast-stream": "^0.2.1",
+        "cont": "~1.0.3",
+        "cross-spawn": "^5.1.0",
+        "deep-equal": "^1.0.1",
+        "explain-error": "^1.0.3",
+        "has-network": "0.0.1",
+        "ip": "^0.3.3",
+        "mdmanifest": "^1.0.4",
+        "minimist": "^1.1.3",
+        "mkdirp": "~0.5.0",
+        "multiblob": "^1.13.0",
+        "multicb": "^1.0.0",
+        "multiserver": "^1.13.4",
+        "muxrpc": "^6.4.0",
+        "muxrpc-validation": "^2.0.0",
+        "muxrpcli": "^1.0.0",
+        "mv": "^2.1.1",
+        "non-private-ip": "^1.4.3",
+        "observ-debounce": "^1.1.1",
+        "obv": "0.0.1",
+        "on-change-network": "0.0.2",
+        "on-wakeup": "^1.0.0",
+        "osenv": "^0.1.5",
+        "pull-abortable": "~4.1.0",
+        "pull-cat": "~1.1.5",
+        "pull-file": "^1.0.0",
+        "pull-flatmap": "0.0.1",
+        "pull-inactivity": "~2.1.1",
+        "pull-level": "^2.0.2",
+        "pull-many": "~1.0.6",
+        "pull-next": "^1.0.0",
+        "pull-notify": "0.1.1",
+        "pull-paramap": "~1.2.1",
+        "pull-ping": "^2.0.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.2",
+        "pull-stream-to-stream": "~1.3.0",
+        "pull-stringify": "~1.2.2",
+        "rimraf": "^2.4.2",
+        "secret-stack": "^4.2.1",
+        "secure-scuttlebutt": "^18.2.0",
+        "ssb-blobs": "^1.1.4",
+        "ssb-client": "^4.5.7",
+        "ssb-config": "^2.3.0",
+        "ssb-ebt": "^5.1.4",
+        "ssb-friends": "^3.1.3",
+        "ssb-keys": "^7.0.13",
+        "ssb-links": "^3.0.2",
+        "ssb-msgs": "~5.2.0",
+        "ssb-query": "^2.1.0",
+        "ssb-ref": "^2.9.1",
+        "ssb-ws": "^2.1.1",
+        "statistics": "^3.0.0",
+        "stream-to-pull-stream": "^1.6.10",
+        "zerr": "^1.0.0"
+      },
+      "dependencies": {
+        "pull-abortable": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
+          "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "secret-stack": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-4.2.1.tgz",
+          "integrity": "sha512-R4pn1zVaspQUqpC3iKLvA476pfftzE8AZTfMnd7TQpuVdGML0wsLYp4wmU4NZERHYsr0g99JnwUH5ll9n0APjg==",
+          "requires": {
+            "hoox": "0.0.1",
+            "ip": "^1.1.5",
+            "map-merge": "^1.1.0",
+            "multiserver": "^1.13.0",
+            "muxrpc": "^6.4.0",
+            "non-private-ip": "^1.4.3",
+            "pull-inactivity": "~2.1.1",
+            "pull-rate": "^1.0.2",
+            "pull-stream": "^3.4.5",
+            "stream-to-pull-stream": "^1.6.1"
+          },
+          "dependencies": {
+            "ip": {
+              "version": "1.1.5",
+              "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+              "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+            }
+          }
+        },
+        "ssb-client": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.6.0.tgz",
+          "integrity": "sha512-LyH5Y/U7xvafmAuG1puyhNv4G3Ew9xC67dYgRX0wwbUf5iT422WB1Cvat9qGFAu3/BQbdctXtdEQPxaAn0+hYA==",
+          "requires": {
+            "explain-error": "^1.0.1",
+            "multicb": "^1.2.1",
+            "multiserver": "^1.13.2",
+            "muxrpc": "^6.4.0",
+            "pull-hash": "^1.0.0",
+            "pull-stream": "^3.6.0",
+            "ssb-config": "^2.2.0",
+            "ssb-keys": "^7.0.13"
+          }
+        },
+        "ssb-keys": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.16.tgz",
+          "integrity": "sha512-EhLkRzgF7YaRc47L8YZb+TcxEXZy9DPWCF+vCt5nSNm8Oj+Pz8pBVSOlrLKZVbcAKFjIJhqY32oTjknu3E1KVQ==",
+          "requires": {
+            "chloride": "^2.2.8",
+            "mkdirp": "~0.5.0",
+            "private-box": "^0.2.1"
+          }
+        }
+      }
+    },
+    "secret-handshake": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-0.5.0.tgz",
+      "integrity": "sha1-jOSc0yNaLh2a1kDS4CKws7iimZU=",
+      "requires": {
+        "chloride": "^2.0.1",
+        "deep-equal": "~1.0.0",
+        "pull-box-stream": "^1.0.9",
+        "pull-cat": "~1.1.5",
+        "pull-defer": "^0.2.2",
+        "pull-handshake": "^1.1.1",
+        "pull-pair": "^1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.2",
+        "pull-stream": "^3.2.0",
+        "stream-to-pull-stream": "^1.6.2"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "secret-stack": {
+      "version": "2.5.2",
+      "resolved": "http://registry.npmjs.org/secret-stack/-/secret-stack-2.5.2.tgz",
+      "integrity": "sha1-rzJWFG5XPGLaf4YOjz4vbQHaaxQ=",
+      "requires": {
+        "hoox": "0.0.1",
+        "map-merge": "^1.1.0",
+        "muxrpc": "^6.2.2",
+        "non-private-ip": "^1.3.0",
+        "pull-inactivity": "~2.1.1",
+        "pull-stream": "~2.27.0",
+        "secret-handshake": "^0.5.0",
+        "stream-to-pull-stream": "^1.6.1"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "non-private-ip": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+          "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
+          "requires": {
+            "ip": "^1.1.5"
+          }
+        },
+        "pull-stream": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.27.0.tgz",
+          "integrity": "sha1-/fDrkQzcQEHWWVbAC+4w270AoGg=",
+          "requires": {
+            "pull-core": "~1.1.0"
+          }
+        }
+      }
+    },
+    "secure-scuttlebutt": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.2.0.tgz",
+      "integrity": "sha512-rBK6P3A4MsZI4lrzaf/dbJJDIxuJXO6y3GUeNngb5IJlcagCNJ+zNZcd19rDURfU8tMgOyw+rEwGIs2ExLQTdg==",
+      "requires": {
+        "async-write": "^2.1.0",
+        "cont": "~1.0.0",
+        "deep-equal": "~0.2.1",
+        "explain-error": "~1.0.1",
+        "flumecodec": "0.0.1",
+        "flumedb": "^0.4.2",
+        "flumelog-offset": "^3.3.1",
+        "flumeview-hashtable": "^1.0.3",
+        "flumeview-level": "^3.0.5",
+        "flumeview-reduce": "^1.3.9",
+        "level": "^3.0.1",
+        "level-sublevel": "^6.6.2",
+        "ltgt": "^2.2.0",
+        "monotonic-timestamp": "~0.0.8",
+        "obv": "0.0.1",
+        "pull-cont": "0.0.0",
+        "pull-level": "^2.0.3",
+        "pull-live": "^1.0.1",
+        "pull-notify": "^0.1.0",
+        "pull-paramap": "^1.1.6",
+        "pull-stream": "^3.4.0",
+        "ssb-keys": "^7.0.15",
+        "ssb-msgs": "^5.0.0",
+        "ssb-ref": "^2.0.0",
+        "ssb-validate": "^3.0.1",
+        "typewiselite": "^1.0.0"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        },
+        "ssb-keys": {
+          "version": "7.0.16",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.16.tgz",
+          "integrity": "sha512-EhLkRzgF7YaRc47L8YZb+TcxEXZy9DPWCF+vCt5nSNm8Oj+Pz8pBVSOlrLKZVbcAKFjIJhqY32oTjknu3E1KVQ==",
+          "requires": {
+            "chloride": "^2.2.8",
+            "mkdirp": "~0.5.0",
+            "private-box": "^0.2.1"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+    },
+    "separator-escape": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
+      "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "sha.js": {
+      "version": "2.4.5",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+      "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
+      "requires": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shellsubstitute": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
+      "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "smart-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
+      "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
+    },
+    "socks": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz",
+      "integrity": "sha512-0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.0.1"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        }
+      }
+    },
+    "socks5-client": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/socks5-client/-/socks5-client-1.2.6.tgz",
+      "integrity": "sha512-6ly0ZYGQaX8vBZvnRnRKT5yixfFEuQVxvYL5UGb7EFarP2d1yoWRJRBVfLKkBK5nOzX862EhhzOYwgZxRARwlQ==",
+      "requires": {
+        "ip-address": "~5.8.0"
+      }
+    },
+    "socks5-http-client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/socks5-http-client/-/socks5-http-client-1.0.4.tgz",
+      "integrity": "sha512-K16meYkltPtps6yDOqK9Mwlfz+pdD2kQQQ/TCO/gu2AImUmfO6nF2uXX1YWrPs4NCfClQNih19wqLXmuUcZCrA==",
+      "requires": {
+        "socks5-client": "~1.2.6"
+      }
+    },
+    "sodium-browserify": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.4.tgz",
+      "integrity": "sha512-IYcxKje/uf/c3a7VhZYJLlUxWMcktfbD4AjqHjUD1/VWKjj0Oq5wNbX8wjJOWVO9UhUMqJQiOn2xFbzKWBmy5w==",
+      "requires": {
+        "libsodium-wrappers": "^0.7.3",
+        "sha.js": "2.4.5",
+        "sodium-browserify-tweetnacl": "^0.2.3",
+        "tweetnacl": "^0.14.1"
+      }
+    },
+    "sodium-browserify-tweetnacl": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
+      "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
+      "requires": {
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^0.14.1",
+        "tweetnacl-auth": "^0.3.0"
+      },
+      "dependencies": {
+        "sha.js": {
+          "version": "2.4.11",
+          "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
+    "sodium-chloride": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
+      "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
+    },
+    "sodium-native": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
+      "integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
+      "optional": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "nan": "^2.4.0",
+        "node-gyp-build": "^3.0.0"
+      }
+    },
+    "split-buffer": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
+      "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
+    },
+    "sprintf-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.0.tgz",
+      "integrity": "sha1-z/yvcC2vZeo5u04PorKZzsGhvkY="
+    },
+    "ssb-blobs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.5.tgz",
+      "integrity": "sha512-DeeInkFU8oN1mYlPVrqrm9tupf6wze4HuowK7N2vv/O+UeSLuYPU1p4HrxSqdAPvUabr0OtvbFA6z1T4nw+9fw==",
+      "requires": {
+        "cont": "^1.0.3",
+        "level": "^3.0.0",
+        "multiblob": "^1.12.0",
+        "pull-level": "^2.0.4",
+        "pull-notify": "^0.1.0",
+        "pull-stream": "^3.3.0",
+        "ssb-ref": "^2.3.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "ssb-client": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-3.1.1.tgz",
+      "integrity": "sha1-BCFHcHkjckEgaCX6B0jqZEnXb9I=",
+      "requires": {
+        "explain-error": "^1.0.1",
+        "secret-stack": "^2.1.0",
+        "ssb-config": "^2.0.0",
+        "ssb-keys": "^5.0.0"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "non-private-ip": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+          "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
+          "requires": {
+            "ip": "^1.1.5"
+          }
+        },
+        "ssb-config": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.1.tgz",
+          "integrity": "sha512-n2gR5vZnBk5ufgvhtKRzQRR/npUwtTtIxuZ7lUOEn5Ao+twx3g5ykJ3LAnIwu7A1HnIBmYUBq9FWJfORT2jwKQ==",
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "non-private-ip": "^1.2.1",
+            "os-homedir": "^1.0.1",
+            "rc": "^1.1.6"
+          }
+        }
+      }
+    },
+    "ssb-config": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.1.tgz",
+      "integrity": "sha512-n2gR5vZnBk5ufgvhtKRzQRR/npUwtTtIxuZ7lUOEn5Ao+twx3g5ykJ3LAnIwu7A1HnIBmYUBq9FWJfORT2jwKQ==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "non-private-ip": "^1.2.1",
+        "os-homedir": "^1.0.1",
+        "rc": "^1.1.6"
+      }
+    },
+    "ssb-ebt": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.2.3.tgz",
+      "integrity": "sha512-LTIry3qRZRLqv3l97tcd22dNiLjZHz7Ynot0OQFG10zL4jsECSkSxMUqSwrFUTfZEySUxhAx92TDcafDy+/J3A==",
+      "requires": {
+        "base64-url": "^2.2.0",
+        "epidemic-broadcast-trees": "^6.3.1",
+        "lossy-store": "^1.2.3",
+        "pull-stream": "^3.5.0",
+        "push-stream-to-pull-stream": "^1.0.0",
+        "ssb-ref": "^2.9.1"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "ssb-friends": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-3.1.3.tgz",
+      "integrity": "sha512-bufgvAcqjAyjKfmh788dr3fV9YYrIgdkIhfETPHidbgIKgx15clNUzjP/s7FZk2PwwrjHyQ54kE0BR2em6u/nQ==",
+      "requires": {
+        "flumeview-reduce": "^1.3.0",
+        "graphreduce": "^3.0.3",
+        "layered-graph": "^1.0.0",
+        "obv": "0.0.1",
+        "pull-cont": "^0.1.1",
+        "pull-flatmap": "0.0.1",
+        "pull-stream": "^3.6.0",
+        "ssb-ref": "^2.7.1"
+      },
+      "dependencies": {
+        "pull-cont": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
+          "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "ssb-keys": {
+      "version": "5.1.2",
+      "resolved": "http://registry.npmjs.org/ssb-keys/-/ssb-keys-5.1.2.tgz",
+      "integrity": "sha1-KxnEtmpmuaMMKtGFRCdxVq3OVgs=",
+      "requires": {
+        "blake2s": "~1.0.0",
+        "chloride": "^2.0.1",
+        "deep-equal": "~0.2.1",
+        "hmac": "~1.0.1",
+        "mkdirp": "~0.5.0",
+        "private-box": "~0.0.3",
+        "ssb-ref": "^2.0.0"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+        },
+        "private-box": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.0.3.tgz",
+          "integrity": "sha1-mfzSRI6uOut20KnjLww8CtyO7Sk=",
+          "requires": {
+            "chloride": "^2.0.1"
+          }
+        }
+      }
+    },
+    "ssb-links": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.3.tgz",
+      "integrity": "sha512-x09ShIMjwvdZI7aDZm8kc1v5YCGZa9ulCOoxrf/RYJ98s5gbTfO9CBCzeMBAeQ5kRwSuKjiOxJHdeEBkj4Y6hw==",
+      "requires": {
+        "flumeview-query": "^6.0.0",
+        "map-filter-reduce": "^2.0.0",
+        "pull-stream": "^3.1.0",
+        "ssb-msgs": "^5.2.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "ssb-msgs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
+      "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
+      "requires": {
+        "ssb-ref": "^2.0.0"
+      }
+    },
+    "ssb-query": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.2.1.tgz",
+      "integrity": "sha512-eAbTVPHYLJ/Cp8jO7uFFXY7L3RhYKlGIhTEM1xjbz3p4/Dysl6DPyWTz7JF+lXhz5AznfjzZNfZjMnX3GJtIbA==",
+      "requires": {
+        "explain-error": "^1.0.1",
+        "flumeview-query": "github:mmckegg/flumeview-query#59afdf210dbd8bdf53aeea7dcfaaec1c77e7d733",
+        "pull-stream": "^3.6.2"
+      },
+      "dependencies": {
+        "flumeview-query": {
+          "version": "github:mmckegg/flumeview-query#59afdf210dbd8bdf53aeea7dcfaaec1c77e7d733",
+          "from": "github:mmckegg/flumeview-query#map",
+          "requires": {
+            "deep-equal": "^1.0.1",
+            "flumeview-level": "^3.0.0",
+            "map-filter-reduce": "^3.0.7",
+            "pull-flatmap": "0.0.1",
+            "pull-paramap": "^1.1.3",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "^3.4.0"
+          }
+        },
+        "map-filter-reduce": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.1.0.tgz",
+          "integrity": "sha512-os2GlG1lEWRSAvAb9iqfapQ0I1GRXSA+alSjQl0DB7XxNyDx2/VOVAEVhK7EMsqwDDCWNTBSstoo1roc7U5H0w==",
+          "requires": {
+            "binary-search": "^1.2.0",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "^3.4.3",
+            "typewiselite": "^1.0.0"
+          }
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "ssb-ref": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.2.tgz",
+      "integrity": "sha512-40A+o3iNAgr/sMH4V6/f3l2dhzUb5ZhTwZdrlKFu1ti+uZrKNUkH/E8j5NIZpj2rDq0PDXkACSVJgPGwltfQRA==",
+      "requires": {
+        "ip": "^1.1.3",
+        "is-valid-domain": "~0.0.1"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        }
+      }
+    },
+    "ssb-validate": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-3.0.11.tgz",
+      "integrity": "sha512-mZPI9HKZtqPP7Qi26B0GR7HqYmmcELEaoj5zr8TlUcULg9BOZy7f4VSzcKZ36LIkvpuK2sfA6znxIlBLq78fjg==",
+      "requires": {
+        "ssb-ref": "^2.6.2"
+      }
+    },
+    "ssb-ws": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-2.1.1.tgz",
+      "integrity": "sha512-1fK/jXI6lKZadRJDr49t+6yMmWynp6PFrADs3Whmy8IslnYGl83ujhlpRIBvCn1EuVHjV7yLsIiJ8a0X2Kg0DQ==",
+      "requires": {
+        "emoji-server": "^1.0.0",
+        "multiblob-http": "^0.4.1",
+        "multiserver": "^1.2.0",
+        "muxrpc": "^6.3.3",
+        "pull-box-stream": "^1.0.13",
+        "ssb-ref": "^2.3.0",
+        "stack": "^0.1.0"
+      }
+    },
+    "stack": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stack/-/stack-0.1.0.tgz",
+      "integrity": "sha1-6SNZipvlHmF2gsshzxsoGKRJraI="
+    },
+    "statistics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
+      "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
+    },
+    "stream-to-pull-stream": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.6.10.tgz",
+      "integrity": "sha1-qVqSxgUWlKX3uBaaahJClqmKUxo=",
+      "requires": {
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
+          "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tape": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
+      "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.3",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.7.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
+    "to-vfile": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
+      "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
+      "requires": {
+        "vfile": "^1.0.0"
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "trim-lines": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
+      "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "tweetnacl-auth": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
+      "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
+      "requires": {
+        "tweetnacl": "0.x.x"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
+      "requires": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
+    },
+    "typewiselite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+      "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
+    },
+    "uint48be": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-1.0.2.tgz",
+      "integrity": "sha512-jNn1eEi81BLiZfJkjbiAKPDMj7iFrturKazqpBu0aJYLr6evgkn+9rgkX/gUwPBj5j2Ri5oUelsqC/S1zmpWBA=="
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "unherit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
+    "unified": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
+      "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
+      "requires": {
+        "attach-ware": "^1.0.0",
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "unherit": "^1.0.4",
+        "vfile": "^1.0.0",
+        "ware": "^1.3.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+    },
+    "unist-util-visit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+      "requires": {
+        "unist-util-is": "^2.1.2"
+      }
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vfile": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+      "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
+    },
+    "vfile-find-down": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
+      "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
+      "requires": {
+        "to-vfile": "^1.0.0"
+      }
+    },
+    "vfile-find-up": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
+      "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
+      "requires": {
+        "to-vfile": "^1.0.0"
+      }
+    },
+    "vfile-reporter": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
+      "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
+      "requires": {
+        "chalk": "^1.1.0",
+        "log-symbols": "^1.0.2",
+        "plur": "^2.0.0",
+        "repeat-string": "^1.5.0",
+        "string-width": "^1.0.0",
+        "text-table": "^0.2.0",
+        "vfile-sort": "^1.0.0"
+      }
+    },
+    "vfile-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz",
+      "integrity": "sha1-F+5JG6Q+iVG7IpE/z/MqfcTSNNQ="
+    },
+    "ware": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+      "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+      "requires": {
+        "wrap-fn": "^0.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wrap-fn": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+      "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+      "requires": {
+        "co": "3.1.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "requires": {
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "zerr": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz",
+      "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/arj03/ssb-exporter",
   "dependencies": {
     "pull-stream": "^2.28.4",
-    "scuttlebot": "~7.6.5",
+    "scuttlebot": "~12.0.0",
     "ssb-client": "^3.0.1",
     "ssb-ref": "^2.2.1",
     "sanitize-filename": "^1.5.3",


### PR DESCRIPTION
This solves an error where `fs.writeFile()` expects a callback, where `NotFoundError` is now just passed as an `Error`, some directories are added to `.gitignore`, and Scuttlebot is upgraded to v12 (!).

No problem if these don't get merged, I just did the work locally to test out the repo and wanted to contrib the fixes upstream. This works great!

---

For reference, these are the only commands I've tested and confirmed working:

```
./export-data.js -e export
./import-data.js export
```